### PR TITLE
fix: remove error from useEffect deps in PreviewFrame to stop re-rend…

### DIFF
--- a/src/components/preview/PreviewFrame.tsx
+++ b/src/components/preview/PreviewFrame.tsx
@@ -20,11 +20,6 @@ export function PreviewFrame() {
       try {
         const files = getAllFiles();
 
-        // Clear error first when we have files
-        if (files.size > 0 && error) {
-          setError(null);
-        }
-
         // Find the entry point - look for App.jsx, App.tsx, index.jsx, or index.tsx
         let foundEntryPoint = entryPoint;
         const possibleEntries = [
@@ -96,7 +91,7 @@ export function PreviewFrame() {
     };
 
     updatePreview();
-  }, [refreshTrigger, getAllFiles, entryPoint, error, isFirstLoad]);
+  }, [refreshTrigger, getAllFiles, entryPoint, isFirstLoad]);
 
   if (error) {
     if (error === "firstLoad") {


### PR DESCRIPTION
…er loop

Including error in the useEffect dependency array caused the effect to re-run whenever error state changed. Since the effect also calls setError inside, this created a cycle: transpilation error -> setError -> effect runs again -> clears error -> error recurs -> repeat. This excessive re-rendering made the toggle buttons feel unresponsive.

Removed the redundant early-clear block since the try/catch already handles error state correctly: setError(null) on success, setError(message) on failure.

Fixes #1